### PR TITLE
Prevent redefine rule behavior

### DIFF
--- a/Source/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
+++ b/Source/FakeItEasy.Specs/AssignsOutAndRefParametersSpecs.cs
@@ -1,6 +1,8 @@
 ﻿namespace FakeItEasy.Specs
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
+    using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using Xbehave;
 
@@ -91,6 +93,31 @@
                         subject.MightReturnAKnownValue(out value);
                         value.Should().BeEquivalentTo(knownOutput);
                     });
+        }
+
+        [Scenario]
+        public static void MultipleAssignOutAndRefParameters(
+            IHaveAnOut subject,
+            string outValue,
+            Exception exception)
+        {
+            "establish"
+                .x(() => subject = A.Fake<IHaveAnOut>());
+
+            "when configuring a fake to assign out and ref parameters multiple times"
+                .x(() =>
+                {
+                    var callSpec =
+                        A.CallTo(() => subject.MightReturnAKnownValue(out outValue))
+                            .WithAnyArguments();
+
+                    callSpec.AssignsOutAndRefParameters(new object[] { "test1" });
+
+                    exception = Record.Exception(() => callSpec.AssignsOutAndRefParameters(new object[] { "test2" }));
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
         }
     }
 }

--- a/Source/FakeItEasy.Specs/ConfigurationSpecs.cs
+++ b/Source/FakeItEasy.Specs/ConfigurationSpecs.cs
@@ -1,5 +1,8 @@
 ﻿namespace FakeItEasy.Specs
 {
+    using System;
+    using FakeItEasy.Configuration;
+    using FakeItEasy.Tests.TestHelpers;
     using FluentAssertions;
     using Xbehave;
 
@@ -86,6 +89,90 @@
 
             "it should invoke the callback"
                 .x(() => callbackWasInvoked.Should().BeTrue());
+        }
+
+        [Scenario]
+        public static void MultipleReturns(
+            IFoo fake,
+            IReturnValueArgumentValidationConfiguration<int> configuration,
+            Exception exception)
+        {
+            "establish"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "when configuring multiple returns on the same configuration"
+                .x(() =>
+                {
+                    configuration = A.CallTo(() => fake.Baz());
+                    configuration.Returns(42);
+                    exception = Record.Exception(() => configuration.Returns(0));
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
+        }
+
+        [Scenario]
+        public static void ReturnThenThrow(
+            IFoo fake,
+            IReturnValueArgumentValidationConfiguration<int> configuration,
+            Exception exception)
+        {
+            "establish"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "when configuring a return then a throw on the same configuration"
+                .x(() =>
+                {
+                    configuration = A.CallTo(() => fake.Baz());
+                    configuration.Returns(42);
+                    exception = Record.Exception(() => configuration.Throws(new Exception()));
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
+        }
+
+        [Scenario]
+        public static void ReturnThenCallsBaseMethod(
+            IFoo fake,
+            IReturnValueArgumentValidationConfiguration<int> configuration,
+            Exception exception)
+        {
+            "establish"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "when configuring a return then base method call on the same configuration"
+                .x(() =>
+                {
+                    configuration = A.CallTo(() => fake.Baz());
+                    configuration.Returns(42);
+                    exception = Record.Exception(() => configuration.CallsBaseMethod());
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
+        }
+
+        [Scenario]
+        public static void MultipleThrows(
+            IFoo fake,
+            IReturnValueArgumentValidationConfiguration<int> configuration,
+            Exception exception)
+        {
+            "establish"
+                .x(() => fake = A.Fake<IFoo>());
+
+            "when configuring a return then a throw on the same configuration"
+                .x(() =>
+                {
+                    configuration = A.CallTo(() => fake.Baz());
+                    configuration.Throws(new ArgumentNullException());
+                    exception = Record.Exception(() => configuration.Throws(new ArgumentException()));
+                });
+
+            "it should throw an InvalidOperationException"
+                .x(() => exception.Should().BeAnExceptionOfType<InvalidOperationException>());
         }
 
         public class BaseClass

--- a/Source/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
+++ b/Source/FakeItEasy.Tests/Configuration/BuildableCallRuleTests.cs
@@ -258,6 +258,22 @@ namespace FakeItEasy.Tests.Configuration
             descriptionWriter.Builder.ToString().Should().Be(expectedDescription);
         }
 
+        [Test]
+        public void Applicator_should_not_be_settable_more_than_once()
+        {
+            this.rule.Applicator = x => { };
+
+            Assert.Throws<InvalidOperationException>(() => this.rule.Applicator = x => { });
+        }
+
+        [Test]
+        public void OutAndRefParameterProducer_should_not_be_settable_more_than_once()
+        {
+            this.rule.OutAndRefParametersValueProducer = x => new object[0];
+
+            Assert.Throws<InvalidOperationException>(() => this.rule.OutAndRefParametersValueProducer = x => new object[] { "test" });
+        }
+
         private class TestableCallRule
             : BuildableCallRule
         {

--- a/Source/FakeItEasy.Tests/Expressions/ExpressionCallRuleTests.cs
+++ b/Source/FakeItEasy.Tests/Expressions/ExpressionCallRuleTests.cs
@@ -100,7 +100,7 @@
 
         private ExpressionCallRule CreateRule()
         {
-            return new ExpressionCallRule(this.callMatcher) { Applicator = x => { } };
+            return new ExpressionCallRule(this.callMatcher) { };
         }
     }
 }

--- a/Source/FakeItEasy/Configuration/RecordingRuleBuilder.cs
+++ b/Source/FakeItEasy/Configuration/RecordingRuleBuilder.cs
@@ -14,8 +14,6 @@ namespace FakeItEasy.Configuration
         {
             this.rule = rule;
             this.wrappedBuilder = wrappedBuilder;
-
-            rule.Applicator = x => { };
         }
 
         public delegate RecordingRuleBuilder Factory(RecordedCallRule rule, FakeManager fakeObject);

--- a/Source/FakeItEasy/Expressions/ExpressionCallRule.cs
+++ b/Source/FakeItEasy/Expressions/ExpressionCallRule.cs
@@ -21,7 +21,7 @@ namespace FakeItEasy.Expressions
             Guard.AgainstNull(expressionMatcher, "expressionMatcher");
 
             this.ExpressionMatcher = expressionMatcher;
-            this.OutAndRefParametersValueProducer = expressionMatcher.GetOutAndRefParametersValueProducer();
+            this.SetOutAndRefParametersValueProducer(expressionMatcher.GetOutAndRefParametersValueProducer());
         }
         
         /// <summary>


### PR DESCRIPTION
Fixes #534.
Closes #557, which this PR supersedes.
I just rebased @thomaslevesque's commits after I caused a conflict with #568.
All I had to do was resolve the conflicting types for `wherePredicates` in BuildableCallRule.cs.

#557's original description:

> This is in order to prevent an unsupported scenario where the user keeps
> the result of A.CallTo(...) and uses it to define multiple behaviors.
> Doing so would override the existing behavior, not stack the new one,
> even though it's not necessarily what the user would expect. Making it
> illegal prevents confusion. It remains possible to keep the result of
> A.CallTo to make later calls to MustHaveHappened and friends.
> 
> See the comments in FakeItEasy/FakeItEasy#534 for more details.